### PR TITLE
Fix deploy error changing second page html name

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: resolve(__dirname, "index.html"),
-        about: resolve(__dirname, "about.html"),
+        about: resolve(__dirname, "add.html"),
       },
     },
   },


### PR DESCRIPTION
Fix deploy error changing second page html name from about.html to add.html